### PR TITLE
Fix rootName display problem #47

### DIFF
--- a/app/home/down-git.js
+++ b/app/home/down-git.js
@@ -22,8 +22,9 @@ downGitModule.factory('downGitService', [
             info.author = splitPath[1];
             info.repository = splitPath[2];
             info.branch = splitPath[4];
+            
+            info.rootName = decodeURI(splitPath[splitPath.length-1]);
 
-            info.rootName = splitPath[splitPath.length-1];
             if(!!splitPath[4]){
                 info.resPath = repoPath.substring(
                     repoPath.indexOf(splitPath[4])+splitPath[4].length+1


### PR DESCRIPTION
When repo contain characters outside [ASCII character-set](https://www.w3schools.com/charsets/ref_html_ascii.asp), the downloaded zip file's filename will not correct display, because of the working mechanism of the [URL Encoding](https://www.w3schools.com/html/html_urlencode.asp) .
Such as download [this repo's sub dir](https://github.com/PKUanonym/REKCARC-TSC-UHT/tree/master/大一上/计算机科学导论), it should named 计算机科学导论 but "%E8%AE%A1%E7%AE%97%E6%9C%BA%E7%A7%91%E5%AD%A6%E5%AF%BC%E8%AE%BA".