### PR TITLE
Add feature to allow direct single file download with directFile parameter

### DIFF
--- a/app/home/home.js
+++ b/app/home/home.js
@@ -37,12 +37,13 @@ homeModule.config([
                     if ($routeParams.url) {
                         $scope.url = $routeParams.url;
                     }
-
+                    
                     if ($scope.url.match(templateUrl)) {
                         var parameter = {
                             url: $routeParams.url,
                             fileName: $routeParams.fileName,
-                            rootDirectory: $routeParams.rootDirectory
+                            rootDirectory: $routeParams.rootDirectory,
+                            directFile: $routeParams.directFile,
                         };
                         var progress = {
                             isProcessing: $scope.isProcessing,


### PR DESCRIPTION
Add feature to allow direct single file download with `directFile=1` parameter.

Example:
```
https://powernukkit.github.io/DownGit/index.html#/home?directFile=1&url=https://github.com/PowerNukkit/PowerNukkit-Pterodactyl-Egg/blob/master/update-on-server-restart/powernukkit-update-on-restart.json
```

Will download `powernukkit-update-on-restart.json` directly instead of having it alone inside a zip file.

Working example:
https://powernukkit.github.io/DownGit/index.html#/home?directFile=1&url=https://github.com/PowerNukkit/PowerNukkit-Pterodactyl-Egg/blob/master/update-on-server-restart/powernukkit-update-on-restart.json
