### PR TITLE
Ft. autofocus implemented

### DIFF
--- a/app/home/home.html
+++ b/app/home/home.html
@@ -9,7 +9,7 @@
     
     <div class="vertical-space"></div>
     <div class="col-md-6 center-row">
-        <input name="url" type="url" placeholder="GitHub File or Directory Link" class="form-control" ng-model="url" ng-keypress="catchEnter($event)"></input>
+        <input name="url" type="url" placeholder="GitHub File or Directory Link" class="form-control" ng-model="url" ng-keypress="catchEnter($event)" autofocus></input>
     </div>
     <div class="btn-group center-row">
         <button type="button" class="btn btn-default" ng-click="createDownLink()">Create Download Link</button>


### PR DESCRIPTION
When the website loads, the cursor is on the text field so the user can just "ctrl + v" to paste the link instead of clicking it with the mouse.

I really loved this service, and this was the feature that would help users like me to reduce our development time and come more to this website to download github repositories. 